### PR TITLE
Fixes "Invalid network" error for regtest invoices

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -160,7 +160,7 @@ function parsePrefix(prefix) {
 }
 
 function isValidNetwork(network) {
-  return network === 'bc' || network === 'tb' || network === 'crt' || network === 'sb';
+  return network === 'bc' || network === 'tb' || network === 'bcrt' || network === 'sb';
 }
 
 function isValidAmount(amount) {


### PR DESCRIPTION
I was having trouble decoding regtest invoices. I believe the network prefix isn't correct. Changing 'crt' to 'bcrt' solved the issue for me.